### PR TITLE
Updated for 6.25

### DIFF
--- a/NSE/http-screenshot.nse
+++ b/NSE/http-screenshot.nse
@@ -25,6 +25,7 @@ license = "GPLv2"
 
 categories = {"discovery", "safe"}
 
+-- Updated the NSE Script imports and variable declarations
 local shortport = require "shortport"
 
 local stdnse = require "stdnse"


### PR DESCRIPTION
Updated this to work on 6.25.  Tested against multiple domains.  Works against nearly all website I've tested against.  Only odd issue was very random small website, it thinks wkhtmltoimage-i386 isn't in the path.  Only seems to happen against really small websites.  Testing against google, cnn, etc all work, leading me to believe it may be an odd bug with the website tested against, not the server.
