### PR TITLE
Fixed Freeze on 401

### DIFF
--- a/NSE/http-screenshot.nse
+++ b/NSE/http-screenshot.nse
@@ -30,6 +30,9 @@ local shortport = require "shortport"
 
 local stdnse = require "stdnse"
 
+-- Added HTTP to detect response code to abort on 401
+local http = require "http"
+
 portrule = shortport.http
 
 action = function(host, port)
@@ -46,6 +49,13 @@ action = function(host, port)
 	if ssl == "ssl" then
 		prefix = "https"	
 	end
+
+        local answer = http.get(host, port, "/", { bypass_cache = true })
+
+        if answer.status == 401 then
+                result = "Page requires authentication (401). Aborting Script"
+                return stdnse.format_output(true,  result)
+        end
 
 	-- Execute the shell command wkhtmltoimage-i386 <url> <filename>
 	local cmd = "wkhtmltoimage-i386 -n " .. prefix .. "://" .. host.ip .. ":" .. port.number .. " " .. filename .. " 2> /dev/null   >/dev/null"


### PR DESCRIPTION
If you encounter a web server requesting basic auth credentials (401 HTTP Response), the script will freeze and require the user to force the script to quit. This new addition to the code requests the page first, detects if the response is a 401 and will return a message to the user if it encounters an authorization request. 

Cost: two HTTP requests are made instead of only one.

Tested on HTTP and HTTPS against an apache basic auth.